### PR TITLE
fix typo from ad to as

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -222,3 +222,6 @@ farmOS runs on top of Drupal. From the FarmData2 perspective this is largely tra
 #### drush ####
 
 For a few particular tasks related to initializtion and configuration FarmData2 makes use of [drush](https://www.drush.org/latest/) to interact with the Drupal instance on which farmOS is running. As it is discovered that more information is necessary it will be added here.
+
+
+#####Mychange##########


### PR DESCRIPTION
__Pull Request Description__

fix typo in the file from ad to as 
exactly: Fixes #9

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
