### PR TITLE
Fix typo: Change 'starts' to 'start' in the 'Starting FarmData2' sect…

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -84,7 +84,7 @@ To start FarmData2 ensure that you are in the `docker` directory in the reposito
 ./fd2-up.bash
 ```
 
-This command will starts up the docker containers that are used by FarmData2. There will be lots of output from this command and the first time you run it, it may take a while to complete as it pulls, downloads and extracts the docker images to your machine.
+This command will start up the docker containers that are used by FarmData2. There will be lots of output from this command and the first time you run it, it may take a while to complete as it pulls, downloads and extracts the docker images to your machine.
 
 If you encounter an error similar to `Cannot start service www`, it can likely be fixed by entering the command
 ```


### PR DESCRIPTION
…ion of INSTALL.md

__Pull Request Description__

This PR corrects a grammatical error in the 'Starting FarmData2' section of the INSTALL.md file. The verb 'starts' has been corrected to 'start' to accurately describe the process of initiating Docker containers used by FarmData2. This change ensures the documentation is clear and grammatically correct. 
 
Fixes #13


---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
